### PR TITLE
Update order of arguments for click/4 + allow title to be optional

### DIFF
--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -20,6 +20,7 @@ defmodule Pages do
   @type attrs_t() :: Keyword.t() | map()
   @type page_type_t() :: :live_view
   @type http_method() :: :get | :post
+  @type text_filter() :: binary() | Regex.t()
 
   @doc "Instantiates a new page."
   @spec new(Plug.Conn.t()) :: Pages.Driver.t()
@@ -30,8 +31,18 @@ defmodule Pages do
   Simulates clicking on an element at `selector` with title `title`.
   Set the `method` param to `:post` to click on a link that has `data-method=post`.
   """
-  @spec click(Pages.Driver.t(), http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
-  def click(%module{} = page, method \\ :get, title, selector), do: module.click(page, method, title, selector)
+  @spec click(Pages.Driver.t(), http_method(), text_filter(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, method, title, selector), do: module.click(page, method, title, selector)
+
+  @spec click(Pages.Driver.t(), http_method(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, :get, selector), do: module.click(page, :get, nil, selector)
+  def click(%module{} = page, :post, selector), do: module.click(page, :post, nil, selector)
+
+  @spec click(Pages.Driver.t(), text_filter(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, title, selector), do: module.click(page, :get, title, selector)
+
+  @spec click(Pages.Driver.t(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, selector), do: module.click(page, :get, nil, selector)
 
   @doc """
   Render a change to the element at `selector` with the value `value`. See `Phoenix.LiveViewTest.render_change/2` for

--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -27,11 +27,11 @@ defmodule Pages do
   def new(%Plug.Conn{} = conn), do: Pages.Driver.Conn.new(conn)
 
   @doc """
-  Simulates clicking on an element at `selector` with title `title` (if provided).
+  Simulates clicking on an element at `selector` with title `title`.
   Set the `method` param to `:post` to click on a link that has `data-method=post`.
   """
-  @spec click(Pages.Driver.t(), http_method(), binary() | nil, Hq.Css.selector()) :: Pages.Driver.t()
-  def click(%module{} = page, selector, title \\ nil, method \\ :get), do: module.click(page, selector, title, method)
+  @spec click(Pages.Driver.t(), http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, method \\ :get, title, selector), do: module.click(page, method, title, selector)
 
   @doc """
   Render a change to the element at `selector` with the value `value`. See `Phoenix.LiveViewTest.render_change/2` for

--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -30,8 +30,8 @@ defmodule Pages do
   Simulates clicking on an element at `selector` with title `title` (if provided).
   Set the `method` param to `:post` to click on a link that has `data-method=post`.
   """
-  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
-  def click(%module{} = page, title \\ nil, selector, method \\ :get), do: module.click(page, title, selector, method)
+  @spec click(Pages.Driver.t(), http_method(), binary() | nil, Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, selector, title \\ nil, method \\ :get), do: module.click(page, selector, title, method)
 
   @doc """
   Render a change to the element at `selector` with the value `value`. See `Phoenix.LiveViewTest.render_change/2` for

--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -30,8 +30,8 @@ defmodule Pages do
   Simulates clicking on an element at `selector` with title `title` (if provided).
   Set the `method` param to `:post` to click on a link that has `data-method=post`.
   """
-  @spec click(Pages.Driver.t(), http_method(), binary() | nil, Hq.Css.selector()) :: Pages.Driver.t()
-  def click(%module{} = page, selector, title \\ nil, method \\ :get), do: module.click(page, selector, title, method)
+  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, title \\ nil, selector, method \\ :get), do: module.click(page, title, selector, method)
 
   @doc """
   Render a change to the element at `selector` with the value `value`. See `Phoenix.LiveViewTest.render_change/2` for

--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -27,11 +27,11 @@ defmodule Pages do
   def new(%Plug.Conn{} = conn), do: Pages.Driver.Conn.new(conn)
 
   @doc """
-  Simulates clicking on an element at `selector` with title `title`.
+  Simulates clicking on an element at `selector` with title `title` (if provided).
   Set the `method` param to `:post` to click on a link that has `data-method=post`.
   """
-  @spec click(Pages.Driver.t(), http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
-  def click(%module{} = page, method \\ :get, title, selector), do: module.click(page, method, title, selector)
+  @spec click(Pages.Driver.t(), http_method(), binary() | nil, Hq.Css.selector()) :: Pages.Driver.t()
+  def click(%module{} = page, selector, title \\ nil, method \\ :get), do: module.click(page, selector, title, method)
 
   @doc """
   Render a change to the element at `selector` with the value `value`. See `Phoenix.LiveViewTest.render_change/2` for

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,7 +13,7 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t() | no_return()
+  @callback click(Pages.Driver.t(), Pages.http_method(), Pages.text_filter() | nil, Hq.Css.selector()) :: Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."
   @callback render_change(Pages.Driver.t(), Hq.Css.selector(), Enum.t()) :: Pages.Driver.t()

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,7 +13,7 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) ::
+  @callback click(Pages.Driver.t(), binary() | nil, Hq.Css.selector(), Pages.http_method()) ::
               Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,7 +13,7 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), binary() | nil, Hq.Css.selector(), Pages.http_method()) ::
+  @callback click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) ::
               Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,8 +13,7 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) ::
-              Pages.Driver.t() | no_return()
+  @callback click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."
   @callback render_change(Pages.Driver.t(), Hq.Css.selector(), Enum.t()) :: Pages.Driver.t()

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,7 +13,8 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t() | no_return()
+  @callback click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) ::
+              Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."
   @callback render_change(Pages.Driver.t(), Hq.Css.selector(), Enum.t()) :: Pages.Driver.t()

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -13,7 +13,8 @@ defmodule Pages.Driver do
           | Pages.Driver.LiveView.t()
 
   @doc "Click an element within a page. Implementation for `Pages.click/4`."
-  @callback click(Pages.Driver.t(), Pages.http_method(), Pages.text_filter() | nil, Hq.Css.selector()) :: Pages.Driver.t() | no_return()
+  @callback click(Pages.Driver.t(), Pages.http_method(), Pages.text_filter() | nil, Hq.Css.selector()) ::
+              Pages.Driver.t() | no_return()
 
   @doc "Render a change. Implementation for `Pages.render_change/3`."
   @callback render_change(Pages.Driver.t(), Hq.Css.selector(), Enum.t()) :: Pages.Driver.t()

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,22 +32,28 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Pages.http_method(), Pages.text_filter() | nil, Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(page, :get, title, selector) do
+  def click(page, :get, maybe_title, selector) do
     link = page |> Hq.find!(selector)
     refute_link_method(link)
-    assert_link_text(link, title)
+
+    if title = maybe_title do
+      assert_link_text(link, title)
+    end
 
     page.conn
     |> Pages.Shim.__dispatch(:get, Hq.attr(link, :href))
     |> Pages.new()
   end
 
-  def click(page, :post, title, selector) do
+  def click(page, :post, maybe_title, selector) do
     link = page |> Hq.find!(selector)
     assert_link_method(link, "post")
-    assert_link_text(link, title)
+
+    if title = maybe_title do
+      assert_link_text(link, title)
+    end
 
     page.conn
     |> Pages.Shim.__dispatch(:post, Hq.attr(link, :href), %{

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,28 +32,22 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(page, selector, maybe_title, :get) do
+  def click(page, :get, title, selector) do
     link = page |> Hq.find!(selector)
     refute_link_method(link)
-
-    if title = maybe_title do
-      assert_link_text(link, title)
-    end
+    assert_link_text(link, title)
 
     page.conn
     |> Pages.Shim.__dispatch(:get, Hq.attr(link, :href))
     |> Pages.new()
   end
 
-  def click(page, selector, maybe_title, :post) do
+  def click(page, :post, title, selector) do
     link = page |> Hq.find!(selector)
     assert_link_method(link, "post")
-
-    if title = maybe_title do
-      assert_link_text(link, title)
-    end
+    assert_link_text(link, title)
 
     page.conn
     |> Pages.Shim.__dispatch(:post, Hq.attr(link, :href), %{

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,7 +32,7 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), binary() | nil, Pages.http_method(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
   def click(page, maybe_title, selector, :get) do
     link = page |> Hq.find!(selector)

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,7 +32,7 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), binary() | nil, Pages.http_method(), Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
   def click(page, maybe_title, selector, :get) do
     link = page |> Hq.find!(selector)

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,9 +32,9 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(page, maybe_title, selector, :get) do
+  def click(page, selector, maybe_title, :get) do
     link = page |> Hq.find!(selector)
     refute_link_method(link)
 
@@ -47,7 +47,7 @@ defmodule Pages.Driver.Conn do
     |> Pages.new()
   end
 
-  def click(page, maybe_title, selector, :post) do
+  def click(page, selector, maybe_title, :post) do
     link = page |> Hq.find!(selector)
     assert_link_method(link, "post")
 

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,22 +32,28 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(page, :get, title, selector) do
+  def click(page, selector, maybe_title, :get) do
     link = page |> Hq.find!(selector)
     refute_link_method(link)
-    assert_link_text(link, title)
+
+    if title = maybe_title do
+      assert_link_text(link, title)
+    end
 
     page.conn
     |> Pages.Shim.__dispatch(:get, Hq.attr(link, :href))
     |> Pages.new()
   end
 
-  def click(page, :post, title, selector) do
+  def click(page, selector, maybe_title, :post) do
     link = page |> Hq.find!(selector)
     assert_link_method(link, "post")
-    assert_link_text(link, title)
+
+    if title = maybe_title do
+      assert_link_text(link, title)
+    end
 
     page.conn
     |> Pages.Shim.__dispatch(:post, Hq.attr(link, :href), %{

--- a/lib/pages/driver/conn.ex
+++ b/lib/pages/driver/conn.ex
@@ -32,9 +32,9 @@ defmodule Pages.Driver.Conn do
   # # #
 
   @doc "Simulates clicking on an element at `selector` with title `title`."
-  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), binary() | nil, http_method(), Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(page, selector, maybe_title, :get) do
+  def click(page, maybe_title, selector, :get) do
     link = page |> Hq.find!(selector)
     refute_link_method(link)
 
@@ -47,7 +47,7 @@ defmodule Pages.Driver.Conn do
     |> Pages.new()
   end
 
-  def click(page, selector, maybe_title, :post) do
+  def click(page, maybe_title, selector, :post) do
     link = page |> Hq.find!(selector)
     assert_link_method(link, "post")
 

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -34,17 +34,17 @@ defmodule Pages.Driver.LiveView do
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."
-  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Pages.http_method(), Pages.text_filter() | nil, Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(%__MODULE__{} = page, :get, title, selector) do
+  def click(%__MODULE__{} = page, :get, maybe_title, selector) do
     page.live
-    |> element(Hq.Css.selector(selector), title)
+    |> element(Hq.Css.selector(selector), maybe_title)
     |> render_click()
     |> handle_rendered_result(page)
   end
 
-  def click(%__MODULE__{} = page, :post, title, selector),
-    do: Pages.Driver.Conn.click(page, :post, title, selector)
+  def click(%__MODULE__{} = page, :post, maybe_title, selector),
+    do: Pages.Driver.Conn.click(page, :post, maybe_title, selector)
 
   @doc "Called from `Pages.rerender/1` when the given page is a LiveView."
   @spec rerender(Pages.Driver.t()) :: Pages.Driver.t()

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -34,17 +34,17 @@ defmodule Pages.Driver.LiveView do
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."
-  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(%__MODULE__{} = page, :get, title, selector) do
+  def click(%__MODULE__{} = page, selector, maybe_title, :get) do
     page.live
-    |> element(Hq.Css.selector(selector), title)
+    |> element(Hq.Css.selector(selector), maybe_title)
     |> render_click()
     |> handle_rendered_result(page)
   end
 
-  def click(%__MODULE__{} = page, :post, title, selector),
-    do: Pages.Driver.Conn.click(page, :post, title, selector)
+  def click(%__MODULE__{} = page, selector, maybe_title, :post),
+    do: Pages.Driver.Conn.click(page, selector, maybe_title, :post)
 
   @doc "Called from `Pages.rerender/1` when the given page is a LiveView."
   @spec rerender(Pages.Driver.t()) :: Pages.Driver.t()

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -34,17 +34,17 @@ defmodule Pages.Driver.LiveView do
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."
-  @spec click(Pages.Driver.t(), binary() | nil, Hq.Css.selector(), Pages.http_method()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(%__MODULE__{} = page, maybe_title, selector, :get) do
+  def click(%__MODULE__{} = page, selector, maybe_title, :get) do
     page.live
     |> element(Hq.Css.selector(selector), maybe_title)
     |> render_click()
     |> handle_rendered_result(page)
   end
 
-  def click(%__MODULE__{} = page, maybe_title, selector, :post),
-    do: Pages.Driver.Conn.click(page, maybe_title, selector, :post)
+  def click(%__MODULE__{} = page, selector, maybe_title, :post),
+    do: Pages.Driver.Conn.click(page, selector, maybe_title, :post)
 
   @doc "Called from `Pages.rerender/1` when the given page is a LiveView."
   @spec rerender(Pages.Driver.t()) :: Pages.Driver.t()

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -34,17 +34,17 @@ defmodule Pages.Driver.LiveView do
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."
-  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), binary() | nil, Hq.Css.selector(), Pages.http_method()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(%__MODULE__{} = page, selector, maybe_title, :get) do
+  def click(%__MODULE__{} = page, maybe_title, selector, :get) do
     page.live
     |> element(Hq.Css.selector(selector), maybe_title)
     |> render_click()
     |> handle_rendered_result(page)
   end
 
-  def click(%__MODULE__{} = page, selector, maybe_title, :post),
-    do: Pages.Driver.Conn.click(page, selector, maybe_title, :post)
+  def click(%__MODULE__{} = page, maybe_title, selector, :post),
+    do: Pages.Driver.Conn.click(page, maybe_title, selector, :post)
 
   @doc "Called from `Pages.rerender/1` when the given page is a LiveView."
   @spec rerender(Pages.Driver.t()) :: Pages.Driver.t()

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -34,17 +34,17 @@ defmodule Pages.Driver.LiveView do
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."
-  @spec click(Pages.Driver.t(), Hq.Css.selector(), binary() | nil, Pages.http_method()) :: Pages.Driver.t()
+  @spec click(Pages.Driver.t(), Pages.http_method(), binary(), Hq.Css.selector()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def click(%__MODULE__{} = page, selector, maybe_title, :get) do
+  def click(%__MODULE__{} = page, :get, title, selector) do
     page.live
-    |> element(Hq.Css.selector(selector), maybe_title)
+    |> element(Hq.Css.selector(selector), title)
     |> render_click()
     |> handle_rendered_result(page)
   end
 
-  def click(%__MODULE__{} = page, selector, maybe_title, :post),
-    do: Pages.Driver.Conn.click(page, selector, maybe_title, :post)
+  def click(%__MODULE__{} = page, :post, title, selector),
+    do: Pages.Driver.Conn.click(page, :post, title, selector)
 
   @doc "Called from `Pages.rerender/1` when the given page is a LiveView."
   @spec rerender(Pages.Driver.t()) :: Pages.Driver.t()


### PR DESCRIPTION
Hello, here's my PR for making click/4's title an optional argument.

Due to elixir's rules for applying default arguments, I made the decision to move the http_method default to the end, and moved `title \\ nil` as the second argument. This is because we will wish to override the `title` default more often than we wish to override the `method` default. Now the `click/4` can be used in four different ways:

```elixir
# Defaults: title = nil, method = :get
Pages.click(page, "[data-role=my-data-role]")
# OR
Pages.click(page, data_role: "my-data-role")

# Defaults: method = :get
Pages.click(page, "My Special Link", "[data-role=my-data-role]")
# OR
Pages.click(page, "My Special Link", data_role: "my-data-role")

# Override method, no title selector
Pages.click(page, nil "[data-role=my-data-role]", :post)
# OR
Pages.click(page, nil, [data_role: "my-data-role"], :post)

# No defaults
Pages.click(page, "My Special Link", "[data-role=my-data-role]", :post)
# OR
Pages.click(page, "My Special Link", [data_role: "my-data-role"], :post)
```

Note that in the last example, we must write our selector as `[data_role: "my-data-role"]`, because the selector is no longer the last argument. In my opinion this tradeoff is worth it; it's probably uncommon to want to specify a title, a selector, and `:post`. If you can think of a cleaner solution to the ordering/defaults problem, I'm all ears.