### PR TITLE
Fix: downgrade liveview driver to conn

### DIFF
--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -33,6 +33,9 @@ defmodule Pages.Driver.LiveView do
   def new(%Plug.Conn{} = conn, {:error, {:redirect, %{to: new_path}}}),
     do: new(conn, new_path)
 
+  def new(%Plug.Conn{} = conn, {:error, :nosession}),
+    do: Pages.new(conn)
+
   # # #
 
   @doc "Called from `Pages.click/4` when the given page is a LiveView."


### PR DESCRIPTION
If new_live/2 returns {:error, :nosession} it means we're trying to access a non-liveview page with the liveview driver, so downgrade to a conn driver with `Pages.new/1`

This fixes an outstanding `fixme_by` in allegro