### PR TITLE
Include an option on handle_redirect to take a custom timeout.

### DIFF
--- a/lib/pages.ex
+++ b/lib/pages.ex
@@ -65,8 +65,8 @@ defmodule Pages do
   Handles cases where the server issues a redirect to the client without a synchronous interaction from the
   user. This may be used to handle redirects issued from `c:Phoenix.LiveView.handle_info/2` callbacks, for instance.
   """
-  @spec handle_redirect(Pages.Driver.t()) :: Pages.result()
-  def handle_redirect(%module{} = page), do: module.handle_redirect(page)
+  @spec handle_redirect(Pages.Driver.t(), keyword()) :: Pages.result()
+  def handle_redirect(%module{} = page, options \\ []), do: module.handle_redirect(page, options)
 
   @doc """
   Attempt to open the current page in a web browser.

--- a/lib/pages/driver.ex
+++ b/lib/pages/driver.ex
@@ -17,7 +17,7 @@ defmodule Pages.Driver do
               Pages.result() | no_return()
 
   @doc "Wait for a server-issued redirect. Implementation for `Pages.handle_redirect/1`."
-  @callback handle_redirect(Pages.Driver.t()) :: Pages.result()
+  @callback handle_redirect(Pages.Driver.t(), keyword()) :: Pages.result()
 
   @doc "Attempt to open the current page in a web browser."
   @callback open_browser(Pages.Driver.t()) :: Pages.Driver.t()
@@ -93,7 +93,7 @@ defmodule Pages.Driver do
 
   @optional_callbacks [
     click: 4,
-    handle_redirect: 1,
+    handle_redirect: 2,
     render_change: 3,
     render_upload: 4,
     render_hook: 4,

--- a/lib/pages/driver/live_view.ex
+++ b/lib/pages/driver/live_view.ex
@@ -67,11 +67,12 @@ defmodule Pages.Driver.LiveView do
   def click(%__MODULE__{} = page, :post, maybe_title, selector),
     do: Pages.Driver.Conn.click(page, :post, maybe_title, selector)
 
-  @doc "Called from `Pages.handle_redirect/1` when the given page is a LiveView."
-  @spec handle_redirect(Pages.Driver.t()) :: Pages.Driver.t()
+  @doc "Called from `Pages.handle_redirect/2` when the given page is a LiveView."
+  @spec handle_redirect(Pages.Driver.t(), keyword()) :: Pages.Driver.t()
   @impl Pages.Driver
-  def handle_redirect(page) do
-    {path, _flash} = page.live |> Phoenix.LiveViewTest.assert_redirect()
+  def handle_redirect(page, options) do
+    timeout = Keyword.get(options, :timeout, Application.fetch_env!(:ex_unit, :assert_receive_timeout))
+    {path, _flash} = page.live |> Phoenix.LiveViewTest.assert_redirect(timeout)
 
     page.conn
     |> Phoenix.ConnTest.ensure_recycled()

--- a/test/pages/driver/live_view_test.exs
+++ b/test/pages/driver/live_view_test.exs
@@ -315,7 +315,7 @@ defmodule Test.Driver.LiveViewTest do
       |> assert_here("live/redirect")
       |> Pages.click(test_role: "trigger-async-redirect")
       |> assert_here("live/redirect")
-      |> Pages.handle_redirect()
+      |> Pages.handle_redirect(timeout: 100)
       |> assert_here("pages/show")
     end
   end


### PR DESCRIPTION
This now allows for `handle_redirect` to take a custom timeout. If nothing is provided, we default to what `Phoenix.LiveViewTest.assert_redirect` already uses(100ms) at: [Phoenix.LiveViewTest.assert_redirect](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#assert_redirect/2).

With this, you can now do something like:

```
page
|> Pages.visit("/login")
|> Pages.handle_redirect(timeout: 500)
```
This should address https://github.com/synchronal/pages/issues/22
