### PR TITLE
Allow for submit_form and update_form to take in date type input.

### DIFF
--- a/lib/pages/form.ex
+++ b/lib/pages/form.ex
@@ -152,7 +152,7 @@ defmodule Pages.Form do
     end
   end
 
-  @text_input_types ~w[email number password search tel text textarea url]
+  @text_input_types ~w[date email number password search tel text textarea url]
   defp update_value(attrs, type, inputs) when type in @text_input_types do
     {"name", name} = List.keyfind(attrs, "name", 0) || {"name", nil}
     value = Map.get(inputs, name)

--- a/test/pages/driver/conn_test.exs
+++ b/test/pages/driver/conn_test.exs
@@ -56,8 +56,21 @@ defmodule Pages.Driver.ConnTest do
                "string_value" => "initial",
                "select_value" => "initial",
                "bool_value" => false,
-               "radio_value" => "initial"
+               "radio_value" => "initial",
+               "date_value" => "2021-01-01"
              }
+    end
+
+    test "submit form handles dates", %{conn: conn} do
+      conn
+      |> Pages.visit("/pages/form")
+      |> Pages.update_form("#form", :form, date_value: "2021-08-15")
+      |> Pages.submit_form("#form")
+      |> assert_here("pages/show")
+
+      assert_receive {:page_controller, :submit, :ok, params}
+
+      assert params["form"]["date_value"] == "2021-08-15"
     end
 
     test "handles non-redirect error renders", %{conn: conn} do
@@ -168,7 +181,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", :form, select_value: "updated")
@@ -196,7 +210,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", :form, bool_value: true)
@@ -224,7 +239,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", :form, radio_value: "updated")
@@ -283,7 +299,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", form: [select_value: "updated"])
@@ -311,7 +328,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", form: [bool_value: true])
@@ -339,7 +357,8 @@ defmodule Pages.Driver.ConnTest do
                select_value: "initial",
                string_value: "initial",
                bool_value: false,
-               radio_value: "initial"
+               radio_value: "initial",
+               date_value: "2021-01-01"
              }
 
       page = page |> Pages.update_form("#form", form: [radio_value: "updated"])

--- a/test/support/site/controller/page_controller.ex
+++ b/test/support/site/controller/page_controller.ex
@@ -11,13 +11,14 @@ defmodule Test.Site.PageController do
     @primary_key false
     embedded_schema do
       field(:bool_value, :boolean)
+      field(:date_value, :date)
       field(:radio_value, Ecto.Enum, values: ~w[initial updated]a)
       field(:select_value, Ecto.Enum, values: ~w[initial updated]a)
       field(:string_value, :string)
     end
 
     @required_attrs ~w[string_value]a
-    @optional_attrs ~w[bool_value radio_value select_value]a
+    @optional_attrs ~w[bool_value date_value radio_value select_value]a
 
     def changeset(params \\ %{}) do
       %__MODULE__{string_value: "initial", select_value: :initial, radio_value: :initial}

--- a/test/support/site/controller/page_view.ex
+++ b/test/support/site/controller/page_view.ex
@@ -23,6 +23,7 @@ defmodule Test.Site.PageView do
       <.form id="form" for={@form} action="/pages/form">
         <.input type="text" field={@form[:string_value]} label="String Value" />
         <.input type="select" field={@form[:select_value]} label="Select Value" options={select_value_options()} />
+        <.input type="date" field={@form[:date_value]} value="2021-01-01" label="Initial" />
         <.input type="checkbox" field={@form[:bool_value]} label="Check Value" />
         <.input
           type="radio"


### PR DESCRIPTION
Trying to submit a form with a type of "date" would raise the following error:

```
 1) test submit_form/2 submit form handles dates (Pages.Driver.ConnTest)
     test/pages/driver/conn_test.exs:64
     ** (FunctionClauseError) no function clause matching in Pages.Form.update_value/3

     The following arguments were given to Pages.Form.update_value/3:

         # 1
         [{"id", "form_date_value"}, {"name", "form[date_value]"}, {"type", "date"}, {"value", "2021-01-01"}]

         # 2
         "date"

         # 3
         %{"form[date_value]" => "2021-08-15"}

     Attempted function clauses (showing 3 out of 3):

         defp update_value(attrs, type, inputs) when type === "email" or type === "number" or type === "password" or type === "search" or type === "tel" or type === "text" or type === "textarea" or type === "url"
         defp update_value(attrs, "checkbox", inputs)
         defp update_value(attrs, "radio", inputs)

     code: |> Pages.update_form("#form", :form, date_value: "2021-08-15")
```

This is due to the valid types for `update_value` not include `date`. This PR adds in the `date` type and a corresponding test.